### PR TITLE
fix cmake config break

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ log_info("Fetching googletest...this might take some time...")
 include(FetchContent)
 FetchContent_Declare(googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG main
 )
 FetchContent_MakeAvailable(googletest)
 


### PR DESCRIPTION
since `master` branch has been deprecated, use `main` instead, reference:
- https://github.com/google/googletest/branches

before
```
➜  /home/mi/local/cmake-logger git:(master) cmake -S . -B build -G Ninja
-- The CXX compiler identification is GNU 13.1.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
~~ 09:50:28 INFO    ******** [ExampleProject]: Fetching googletest...this might take some time... ********
[1/9] Creating directories for 'googletest-populate'
[1/9] Performing download step (git clone) for 'googletest-populate'
Cloning into 'googletest-src'...
fatal: invalid reference: master
CMake Error at googletest-subbuild/googletest-populate-prefix/tmp/googletest-populate-gitclone.cmake:49 (message):
  Failed to checkout tag: 'master'

FAILED: googletest-populate-prefix/src/googletest-populate-stamp/googletest-populate-download /home/mi/local/cmake-logger/build/_deps/googletest-subbuild/googletest-populate-prefix/src/googletest-populate-stamp/googletest-populate-download
cd /home/mi/local/cmake-logger/build/_deps && /home/mi/local/cmake-3.23/cmake-3.23.0-linux-x86_64/bin/cmake -P /home/mi/local/cmake-logger/build/_deps/googletest-subbuild/googletest-populate-prefix/tmp/googletest-populate-gitclone.cmake && /home/mi/local/cmake-3.23/cmake-3.23.0-linux-x86_64/bin/cmake -E touch /home/mi/local/cmake-logger/build/_deps/googletest-subbuild/googletest-populate-prefix/src/googletest-populate-stamp/googletest-populate-download
ninja: build stopped: subcommand failed.

CMake Error at /home/mi/local/cmake-3.23/cmake-3.23.0-linux-x86_64/share/cmake-3.23/Modules/FetchContent.cmake:1088 (message):
  Build step for googletest failed: 1
Call Stack (most recent call first):
  /home/mi/local/cmake-3.23/cmake-3.23.0-linux-x86_64/share/cmake-3.23/Modules/FetchContent.cmake:1217:EVAL:2 (__FetchContent_directPopulate)
  /home/mi/local/cmake-3.23/cmake-3.23.0-linux-x86_64/share/cmake-3.23/Modules/FetchContent.cmake:1217 (cmake_language)
  /home/mi/local/cmake-3.23/cmake-3.23.0-linux-x86_64/share/cmake-3.23/Modules/FetchContent.cmake:1260 (FetchContent_Populate)
  CMakeLists.txt:23 (FetchContent_MakeAvailable)

-- Configuring incomplete, errors occurred!
See also "/home/mi/local/cmake-logger/build/CMakeFiles/CMakeOutput.log".
```

after
```
➜  /home/mi/local/cmake-logger git:(master) cmake -S . -B build -G Ninja
~~ 09:50:45 INFO    ******** [ExampleProject]: Fetching googletest...this might take some time... ********
-- The C compiler identification is GNU 13.1.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
~~ 09:50:49 INFO    ******** [ExampleProject]: Initial Time Taken: 4 seconds. ********
~~ 09:50:49 INFO    ******** [ExampleProject]: Time Taken: 4 seconds. ********
~~ 09:50:49 SUCCESS ******** [ExampleProject]: Hello CMakeLogger ********
~~ 09:50:49 DEBUG   ******** [ExampleProject]: Hello CMakeLogger ********
~~ 09:50:49 INFO    ******** [ExampleProject]: Hello CMakeLogger ********
~~ 09:50:49 WARN    ******** [ExampleProject]: Hello CMakeLogger ********
CMake Warning at cmake/CMakeLogger.cmake:203 (message):
Call Stack (most recent call first):
  cmake/CMakeLogger.cmake:98 (CMakeLogger_log)
  CMakeLists.txt:33 (log_warn)

~~ 09:50:49 ERROR   ******** [ExampleProject]: Hello CMakeLogger ********
CMake Error at cmake/CMakeLogger.cmake:203 (message):
Call Stack (most recent call first):
  cmake/CMakeLogger.cmake:94 (CMakeLogger_log)
  CMakeLists.txt:34 (log_error)

~~ 09:50:49 FATAL   ******** [ExampleProject]: Hello CMakeLogger ********
CMake Error at cmake/CMakeLogger.cmake:203 (message):
Call Stack (most recent call first):
  cmake/CMakeLogger.cmake:90 (CMakeLogger_log)
  CMakeLists.txt:35 (log_fatal)

-- Configuring incomplete, errors occurred!
See also "/home/mi/local/cmake-logger/build/CMakeFiles/CMakeOutput.log".
```

Signed-off-by: Junbo Zheng <3273070@qq.com>