### PR TITLE
fix Compatibility with CMake < 3.5 has been removed from CMake.

### DIFF
--- a/cmake/CMakeLogger.cmake
+++ b/cmake/CMakeLogger.cmake
@@ -36,7 +36,7 @@
 #      e.g. log_info("Hello CMakeLogger")
 #
 #   Additionaly, you can configure in your root CMakeLists.txt how logs will be outputed.
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMLOGGER_VERSION "v1.0.1"
   CACHE STRING "CMakeLogger: Version")


### PR DESCRIPTION
fix Compatibility with CMake < 3.5 has been removed from CMake

---

reference:
- https://github.com/eclipse-ecal/ecal/issues/2041
- https://github.com/osrf/homebrew-simulation/issues/3003
- https://www.kitware.com/cmake-4-0-0-available-for-download/
- https://discourse.cmake.org/t/how-to-fix-cmake-minimum-required-deprecation-warning/2487

before(build break)
```
➜  /Users/junbozheng/my/mycpp git:(master) ✗ cmake -S . -B build -G Ninja
-- ######## sub CMAKE_CURRENT_LIST_DIR   -> /Users/junbozheng/my/mycpp/cmake
-- ######## sub CMAKE_CURRENT_SOURCE_DIR -> /Users/junbozheng/my/mycpp
111111111111111111 /Users/junbozheng/my/mycpp/build
CMake Error at build/CMakeLogger.cmake:39 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
Call Stack (most recent call first):
  CMakeLists.txt:67 (include)

-- Configuring incomplete, errors occurred!
```

after(build pass)
```
➜  /Users/junbozheng/my/mycpp git:(master) ✗ cmake -S . -B build -G Ninja
-- ######## sub CMAKE_CURRENT_LIST_DIR   -> /Users/junbozheng/my/mycpp/cmake
-- ######## sub CMAKE_CURRENT_SOURCE_DIR -> /Users/junbozheng/my/mycpp
111111111111111111 /Users/junbozheng/my/mycpp/build
-- Check AddressSanitizer compiler flags for languages: C;CXX
~~ 23:03:24 INFO    ******** [demo]: C Compiler (gcc) Version: 17.0.0.17000013 ********
~~ 23:03:24 INFO    ******** [demo]: C++ Compiler (g++) Version: 17.0.0.17000013 ********
~~ 23:03:24 INFO    ******** [demo]: C Compiler Path: /usr/bin/cc ********
~~ 23:03:24 INFO    ******** [demo]: C++ Compiler Path: /usr/bin/c++ ********
~~ 23:03:24 INFO    ******** [demo]: CMAKE_C_COMPILER_ID AppleClang ********
~~ 23:03:24 INFO    ******** [demo]: CMAKE_CXX_COMPILER_ID AppleClang ********
~~ 23:03:24 INFO    ******** [demo]: CMAKE_C_FLAGS  ********
~~ 23:03:24 INFO    ******** [demo]: CMAKE_CXX_FLAGS  ********
-- ### add subdir 2024
-- ### add subdir cpp
-- ### add subdir hello
-- ### add subdir lib
-- ### add subdir list
-- ### add subdir socket
-- ### add subdir source
~~ 23:03:25 DEBUG   ******** [demo]: ######## parent CMAKE_CURRENT_LIST_DIR   -> /Users/junbozheng/my/mycpp ********
~~ 23:03:25 SUCCESS ******** [demo]: ######## parent CMAKE_CURRENT_SOURCE_DIR -> /Users/junbozheng/my/mycpp ********
-- Configuring done (0.7s)
-- Generating done (0.2s)
-- Build files have been written to: /Users/junbozheng/my/mycpp/build
```

patch diff
```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index f794451..1e2d6e2 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,11 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
 include(test)
 include(add_subdir)
 
+
+message("111111111111111111 ${CMAKE_BINARY_DIR}")
+
+include("${CMAKE_BINARY_DIR}/CMakeLogger.cmake")
+
 set(SANITIZE_ADDRESS
     ON
     CACHE BOOL "enable AddressSanitizer for targets" FORCE)
@@ -81,17 +86,17 @@ endif()
 # AppleClang) set(CMAKE_C_FLAGS "-fsanitize=address -fsanitize=undefined
 # ${CMAKE_C_FLAGS}") endif()
 
-message(STATUS "C Compiler (gcc) Version: ${CMAKE_C_COMPILER_VERSION}")
-message(STATUS "C++ Compiler (g++) Version: ${CMAKE_CXX_COMPILER_VERSION}")
+log_info("C Compiler (gcc) Version: ${CMAKE_C_COMPILER_VERSION}")
+log_info("C++ Compiler (g++) Version: ${CMAKE_CXX_COMPILER_VERSION}")
 
-message(STATUS "C Compiler Path: ${CMAKE_C_COMPILER}")
-message(STATUS "C++ Compiler Path: ${CMAKE_CXX_COMPILER}")
+log_info("C Compiler Path: ${CMAKE_C_COMPILER}")
+log_info("C++ Compiler Path: ${CMAKE_CXX_COMPILER}")
 
-message(STATUS "CMAKE_C_COMPILER_ID ${CMAKE_C_COMPILER_ID}")
-message(STATUS "CMAKE_CXX_COMPILER_ID ${CMAKE_CXX_COMPILER_ID}")
+log_info("CMAKE_C_COMPILER_ID ${CMAKE_C_COMPILER_ID}")
+log_info("CMAKE_CXX_COMPILER_ID ${CMAKE_CXX_COMPILER_ID}")
 
-message(STATUS "CMAKE_C_FLAGS ${CMAKE_C_FLAGS}")
-message(STATUS "CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS}")
+log_info("CMAKE_C_FLAGS ${CMAKE_C_FLAGS}")
+log_info("CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS}")
 
 add_subdir()
 
@@ -105,8 +110,8 @@ target_include_directories(${PROJECT_NAME} PRIVATE external)
 target_link_libraries(${PROJECT_NAME} PRIVATE printf)
 
 # cmake-format: off
-message(STATUS "######## parent CMAKE_CURRENT_LIST_DIR   -> ${CMAKE_CURRENT_LIST_DIR}")
-message(STATUS "######## parent CMAKE_CURRENT_SOURCE_DIR -> ${CMAKE_CURRENT_SOURCE_DIR}")
+log_debug("######## parent CMAKE_CURRENT_LIST_DIR   -> ${CMAKE_CURRENT_LIST_DIR}")
+log_success("######## parent CMAKE_CURRENT_SOURCE_DIR -> ${CMAKE_CURRENT_SOURCE_DIR}")
 # cmake-format: on
 
 add_test(NAME test_demo COMMAND ${PROJECT_NAME})
```

It works fine for me, tested with
```
➜  /Users/junbozheng/my/mycpp git:(master) ✗ cmake --version
cmake version 4.0.1

CMake suite maintained and supported by Kitware (kitware.com/cmake).
➜  /Users/junbozheng/my/mycpp git:(master) ✗ sw_vers
ProductName:            macOS
ProductVersion:         15.5
BuildVersion:           24F74
➜  /Users/junbozheng/my/mycpp git:(master) ✗
```