### PR TITLE
Timer System Refactor with Millisecond Precision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,31 +1,18 @@
 
 # NOTE: This is an example usuage file
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.10)
 
-include("cmake/CMakeLogger.cmake")
+include(cmake/CMakeLogger.cmake)
 
 project(ExampleProject
-  LANGUAGES CXX
-  VERSION 1.0.0
-  DESCRIPTION "A simple CMake logger."
-  HOMEPAGE_URL "https://github.com/giladreich/CMakeLogger"
+  LANGUAGES C CXX
+  VERSION 1.0.1
+  DESCRIPTION "Example project using CMakeLogger."
+  HOMEPAGE_URL "https://github.com/giladreich/cmake-logger"
 )
 
 # Enable colorized logs output (by default it's set to ON)
 set(CMLOGGER_OUTPUT_COLORIZED ON CACHE STRING "" FORCE)
-
-log_reset_timer() # Start the timer to see how long it takes cloning gtest
-log_info("Fetching googletest...this might take some time...")
-include(FetchContent)
-FetchContent_Declare(googletest
-  GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG main
-)
-FetchContent_MakeAvailable(googletest)
-
-# Print time taken
-log_print_initial_time_taken() # print the time taken since cmake initially started.
-log_print_time_taken() # print the time taken since `log_reset_timer` was last called.
 
 log_success("Hello CMakeLogger")
 log_debug("Hello CMakeLogger")
@@ -34,4 +21,32 @@ log_warn("Hello CMakeLogger")
 log_error("Hello CMakeLogger")
 log_fatal("Hello CMakeLogger")
 
+log_info("Timer examples:")
+
+log_info("Example 1 - Short task (milliseconds format)")
+log_reset_timer()
+execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 0.3)
+log_print_time_taken()
+
+log_info("Example 2 - Medium task (seconds format)")
+log_reset_timer()
+execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 1.3)
+log_print_time_taken()
+
+log_info("Example 3 - Long task (minutes format)")
+log_reset_timer()
+# execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 63) # Uncomment to test long task
+log_print_time_taken()
+
+log_info("Example 4 - Manual timer usage")
+log_reset_timer()
+execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 1.2)
+log_time_taken(duration_ms)
+log_format_duration_ms(formatted_duration ${duration_ms})
+log_info("Raw milliseconds: ${duration_ms}ms")
+log_info("Formatted duration: ${formatted_duration}")
+
 add_executable(${PROJECT_NAME} main.cpp)
+
+# print the time taken since cmake initially started.
+log_print_initial_time_taken()


### PR DESCRIPTION
## Overview

This PR refactors the CMakeLogger timer system to provide millisecond precision timing using CMake's built-in functions.

## Changes

### Timing Precision
- Millisecond accuracy using CMake's `string(TIMESTAMP)` with microsecond precision

### Duration Formatting
- Adaptive display: `250ms` → `1.500s` → `2m 30.250s`
- Zero-padded milliseconds for consistent formatting
- Context-appropriate units based on duration

### Example Project Updates
- Replaced FetchContent dependencies with sleep simulations
- Added educational examples demonstrating timer functions

## Technical Improvements

### Before vs After

| Aspect | Before | New Implementation |
|--------|--------|-------------------|
| Precision | Seconds only | Milliseconds with microsecond source |
| Formatting | Basic seconds display | Adaptive ms/s/m formatting |
| Example | Network-dependent FetchContent | Offline sleep simulations |

### Implementation Notes

- Timestamp conversion uses string truncation instead of floating-point math
- Timer variables persist using `CACHE INTERNAL`
- Automatic initialization in `_cmlogger_main()`

## Example Output

```bash
~~ 19:28:25 INFO    [ExampleProject] Timer examples:

~~ 19:28:25 INFO    [ExampleProject] Example 1 - Short task (milliseconds format)
~~ 19:28:25 INFO    [ExampleProject] Time taken: 317ms

~~ 19:28:25 INFO    [ExampleProject] Example 2 - Medium task (seconds format)
~~ 19:28:26 INFO    [ExampleProject] Time taken: 1.318s

~~ 19:28:26 INFO    [ExampleProject] Example 3 - Long task (minutes format)
~~ 19:29:29 INFO    [ExampleProject] Time taken: 1m 3.019s

~~ 19:29:29 INFO    [ExampleProject] Example 4 - Manual timer usage
~~ 19:29:31 INFO    [ExampleProject] Raw milliseconds: 1221ms
~~ 19:29:31 INFO    [ExampleProject] Formatted duration: 1.221s

~~ 19:29:31 INFO    [ExampleProject] Total time since start: 1m 7.027s
```