### PR TITLE
Logger Configuration System Improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,6 @@ project(ExampleProject
   HOMEPAGE_URL "https://github.com/giladreich/cmake-logger"
 )
 
-# Enable colorized logs output (by default it's set to ON)
-set(CMLOGGER_OUTPUT_COLORIZED ON CACHE STRING "" FORCE)
-
 log_success("Hello CMakeLogger")
 log_debug("Hello CMakeLogger")
 log_info("Hello CMakeLogger")

--- a/cmake/CMakeLogger.cmake
+++ b/cmake/CMakeLogger.cmake
@@ -57,31 +57,39 @@ set(CMLOGGER_COLOR_DEBUG       "bold;blue")
 set(CMLOGGER_COLOR_SUCCESS     "bold;green")
 
 set(CMLOGGER_OUTPUT_COLORIZED ON
-  CACHE STRING "CMakeLogger: Colorized output")
-set_property(CACHE CMLOGGER_OUTPUT_COLORIZED PROPERTY STRINGS ON OFF)
+  CACHE BOOL
+  "CMakeLogger: Colorized output"
+)
 
 set(CMLOGGER_OUTPUT_TIMESTAMP ON
-  CACHE STRING "CMakeLogger: Include timestamp in the log output. e.g. '~~ 15:05:14 INFO    My Log'")
-set_property(CACHE CMLOGGER_OUTPUT_TIMESTAMP PROPERTY STRINGS ON OFF)
+  CACHE BOOL
+  "CMakeLogger: Include timestamp in the log output. e.g. '>> 15:05:14.123456 INFO    My Log'"
+)
 
-set(CMLOGGER_OUTPUT_TIMESTAMP_FORMAT "%H:%M:%S"
-  CACHE STRING "CMakeLogger: Timestamp format")
+set(CMLOGGER_OUTPUT_TIMESTAMP_FORMAT "%H:%M:%S.%f"
+  CACHE STRING
+  "CMakeLogger: Timestamp format"
+)
 
-set(CMLOGGER_OUTPUT_WRAP "********"
-  CACHE STRING "CMakeLogger: String to surround your log. e.g. '~~ INFO    **** My Log ****'")
+set(CMLOGGER_OUTPUT_WRAP ""
+  CACHE STRING
+  "CMakeLogger: String to surround your log. e.g. '>> INFO    ##### My Log #####'"
+)
 
-set(CMLOGGER_OUTPUT_PREFIX "~~ "
-  CACHE STRING "CMakeLogger: Log out prefix. e.g. '~~ INFO    My Log'")
+set(CMLOGGER_OUTPUT_PREFIX ">>"
+  CACHE STRING
+  "CMakeLogger: Log out prefix. e.g. '>> INFO    My Log'"
+)
 
 set(CMLOGGER_OUTPUT_PROJECTNAME ON
-  CACHE STRING "CMakeLogger: Include current project name in the log output if exists. e.g. '~~ INFO    [MyProjectName]: My Log'")
-set_property(CACHE CMLOGGER_OUTPUT_PROJECTNAME PROPERTY STRINGS ON OFF)
-
-set(CMLOGGER_TIMERS ON
-  CACHE STRING "CMakeLogger: Turn this off if not desired to use any of the timers functions")
+  CACHE BOOL
+  "CMakeLogger: Include current project name in the log output if exists. e.g. '>> INFO    [MyProjectName]: My Log'"
+)
 
 set(CMLOGGER_VERBOSE ON
-  CACHE STRING "CMakeLogger: Turn this off if not desired to see CMakeLogger internal messages.")
+  CACHE BOOL
+  "CMakeLogger: Turn this off if not desired to see CMakeLogger internal messages."
+)
 
 # END Configurations
 ##################################################################################################################
@@ -249,7 +257,7 @@ function(CMakeLogger_log cmakeMsgType level msg color)
   CMakeLogger_format(${msg} ${level})
 
   if(_CMLOGGER_COLORIZED_OUTPUT)
-    CMakeLogger_execute_echo_color("${CMLOGGER_OUTPUT_PREFIX}${msg}" ${LOG_COLOR} ${LOG_COLOR_BOLD} false)
+    CMakeLogger_execute_echo_color("${CMLOGGER_OUTPUT_PREFIX} ${msg}" ${LOG_COLOR} ${LOG_COLOR_BOLD} false)
 
     # For FATAL_ERROR and WARNING modes, cmake will print the call stack and stop the execution, therefore
     # we passing the original message-mode forward (without text) to maintain the defined behavior of cmake.

--- a/cmake/CMakeLogger.cmake
+++ b/cmake/CMakeLogger.cmake
@@ -248,7 +248,7 @@ function(CMakeLogger_log cmakeMsgType level msg color)
 
   CMakeLogger_format(${msg} ${level})
 
-  if(CMLOGGER_OUTPUT_COLORIZED AND CMLOGGER_CAN_PRINT_COLORS)
+  if(_CMLOGGER_COLORIZED_OUTPUT)
     CMakeLogger_execute_echo_color("${CMLOGGER_OUTPUT_PREFIX}${msg}" ${LOG_COLOR} ${LOG_COLOR_BOLD} false)
 
     # For FATAL_ERROR and WARNING modes, cmake will print the call stack and stop the execution, therefore
@@ -530,6 +530,12 @@ endfunction()
 # 3. Standard environment variables (CLICOLOR, COLORTERM, MAKE_TERMOUT, etc.)
 # 4. Terminal capability detection
 function(_cmlogger_should_colorize_output out_bool)
+  if(NOT CMLOGGER_OUTPUT_COLORIZED)
+    _cmlogger_message("Colorized output disabled by configuration")
+    set(${out_bool} FALSE PARENT_SCOPE)
+    return()
+  endif()
+
   # Override: NO_COLOR disables colors (https://no-color.org/)
   if(DEFINED ENV{NO_COLOR})
     _cmlogger_message("Colors disabled by NO_COLOR")
@@ -673,7 +679,7 @@ function(_cmlogger_main)
     endif()
   endif()
   _cmlogger_message("Colorized output: ${colorized_output}")
-  set(CMLOGGER_CAN_PRINT_COLORS ${colorized_output} PARENT_SCOPE)
+  set(_CMLOGGER_COLORIZED_OUTPUT ${colorized_output} PARENT_SCOPE)
 endfunction()
 
 _cmlogger_main()

--- a/cmake/CMakeLogger.cmake
+++ b/cmake/CMakeLogger.cmake
@@ -38,8 +38,7 @@
 #   Additionaly, you can configure in your root CMakeLists.txt how logs will be outputed.
 cmake_minimum_required(VERSION 3.10)
 
-set(CMLOGGER_VERSION "v1.0.1"
-  CACHE STRING "CMakeLogger: Version")
+set(CMLOGGER_VERSION "v1.0.1")
 
 ##################################################################################################################
 # Configurations

--- a/cmake/CMakeLogger.cmake
+++ b/cmake/CMakeLogger.cmake
@@ -42,10 +42,12 @@ set(CMLOGGER_VERSION "v1.0.1")
 
 ##################################################################################################################
 # Configurations
-# NOTE: It would be better overriding default configurations from your own CMake scripts as needed, instead
-# of modifying them here. e.g. right after including:
-# include(cmake/CMakeLogger.cmake)
-# set(CMLOGGER_OUTPUT_COLORIZED OFF CACHE STRING "" FORCE)
+# NOTE: To override default configurations, create a CMakeLoggerOptions.cmake file in the same directory
+# as this file. This approach provides better organization and cmake-gui compatibility.
+# Example: cmake/CMakeLoggerOptions.cmake with your custom settings.
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/CMakeLoggerOptions.cmake")
+  include("${CMAKE_CURRENT_LIST_DIR}/CMakeLoggerOptions.cmake")
+endif()
 
 # Log Level Colors. Available colors: normal|black|red|green|yellow|blue|magenta|cyan|white
 set(CMLOGGER_COLOR_FATAL       "red")

--- a/cmake/CMakeLoggerOptions.cmake
+++ b/cmake/CMakeLoggerOptions.cmake
@@ -1,0 +1,26 @@
+# Example configuration file for CMakeLogger
+#
+# This file is used to set default configurations for CMakeLogger.
+# It is recommended to use this file to better manage configurations, as it allows
+# for easy overrides and is compatible with cmake-gui for user-friendly
+# configuration management.
+#
+# CMakeLogger will automatically load configurations from this file if it exists.
+#
+# Configuration override methods (because these are cached variables):
+# 1. Use CMakeLoggerOptions.cmake file (recommended)
+# 2. Use command line options (e.g., -DCMLOGGER_OUTPUT_COLORIZED=OFF)
+# 3. Set cached variables in your CMakeLists.txt before include(cmake/CMakeLogger.cmake)
+# 4. Set cached variables anywhere with FORCE (not recommended for cmake-gui compatibility)
+#
+# Using CMakeLoggerOptions.cmake is the recommended approach for managing configurations.
+
+set(CMLOGGER_OUTPUT_COLORIZED ON
+  CACHE BOOL
+  "CMakeLogger: Colorized output"
+)
+
+set(CMLOGGER_OUTPUT_PREFIX ">>"
+  CACHE STRING
+  "CMakeLogger: Log out prefix. e.g. '>> INFO    My Log'"
+)

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,12 +37,15 @@ Each of the functions above receives a string as an argument for the log message
 
 CMakeLogger also allows convenient use of measuring time:
 - `log_reset_timer` - use before starting measuring time
+- `log_time_taken` - get elapsed time in milliseconds (requires output variable)
+- `log_initial_time_taken` - get time since cmake started in milliseconds (requires output variable)
 - `log_print_time_taken` - use after operation is finished
 - `log_print_initial_time_taken` - use to know how long since cmake started
+- `log_format_duration_ms` - format milliseconds into readable duration (requires output variable)
 
-This is useful if certain operations in your scripts take a while and you want to print how long in seconds it took.
+This is useful if certain operations in your scripts take a while and you want to print how long it took.
 
-Apart from the functions mentioned above, CMakeLogger allows different customization by giving the option to override some of configurations that can be found at the beginning of `CMakeLogger.cmake` file.
+Apart from the functions mentioned above, CMakeLogger allows different customization by creating a `CMakeLoggerOptions.cmake` file in the same directory as `CMakeLogger.cmake`. This approach provides better organization and cmake-gui compatibility.
 
 
 See [CMakeLists.txt](https://github.com/giladreich/CMakeLogger/blob/master/CMakeLists.txt) in the root directory for example usage.
@@ -60,6 +63,8 @@ include("cmake/CMakeLogger.cmake")
 
 This will define a set of functions for you to use (listed above).
 
+Optionally, create a `cmake/CMakeLoggerOptions.cmake` file to customize configurations such as output formatting, colors, and prefixes.
+
 Another possible way if you don't want to copy it into your project, is by adding this into your root `CMakeLists.txt`:
 ```cmake
 if(NOT EXISTS "${CMAKE_BINARY_DIR}/CMakeLogger.cmake")
@@ -69,6 +74,8 @@ if(NOT EXISTS "${CMAKE_BINARY_DIR}/CMakeLogger.cmake")
 endif()
 include("${CMAKE_BINARY_DIR}/CMakeLogger.cmake")
 ```
+
+Note: When using the download method, you'll need to manually create `CMakeLoggerOptions.cmake` in your project if you want to customize configurations.
 
 ## Contributing
 


### PR DESCRIPTION
## Overview
This PR improves the CMakeLogger configuration system by adding an external configuration file, fixing cache variable types for better cmake-gui support, and updating documentation.

## Changes

### External Configuration File
- Added `cmake/CMakeLoggerOptions.cmake` for optional external configuration
  - Automatically loaded when present in the same directory
  - Better organization and cmake-gui compatibility
  - Includes documentation and examples

### Configuration Fixes
- Fixed cache variable types for boolean options:
  - `CMLOGGER_OUTPUT_COLORIZED`: STRING → BOOL
  - `CMLOGGER_OUTPUT_TIMESTAMP`: STRING → BOOL
  - `CMLOGGER_OUTPUT_PROJECTNAME`: STRING → BOOL
  - `CMLOGGER_VERBOSE`: STRING → BOOL
- Updated some default values:
  - Timestamp format: `%H:%M:%S` → `%H:%M:%S.%f` (microsecond precision)
  - Output wrap: `"********"` → `""` (no default wrapping)
  - Output prefix: `"~~ "` → `">>"` (simplified)
- Cleaned up color output variable handling

### Code Organization
- Removed unnecessary cache declaration for `CMLOGGER_VERSION`
- Cleaned up example in `CMakeLists.txt`
- Improved configuration documentation

### Documentation Updates
- Updated README.md with current timer functions list
- Added setup instructions for `CMakeLoggerOptions.cmake`
- Clarified configuration approaches

## Technical Details

### Configuration Options
The external configuration file supports multiple override methods (because these are cached variables):
1. Use CMakeLoggerOptions.cmake file (recommended)
2. Use command line options (e.g., -DCMLOGGER_OUTPUT_COLORIZED=OFF)
3. Set cached variables in your CMakeLists.txt before include(cmake/CMakeLogger.cmake)
4. Set cached variables anywhere with FORCE (not recommended for cmake-gui 

### Cache Variable Benefits
- BOOL types enable cmake-gui checkbox controls
- Better type safety and validation
- Improved cmake-gui user experience


Existing configurations continue to work without changes.
